### PR TITLE
Add Gas benchmarking, optimize gas usage throughout contracts

### DIFF
--- a/contracts/DataBroker.sol
+++ b/contracts/DataBroker.sol
@@ -10,6 +10,9 @@ import "./DataSharingToken.sol";
  * @notice Gateway contract that enforces consent verification before allowing data access
  */
 contract DataBroker {
+    error ConsentMissing();
+    error UserNotRegistered();
+
     /// @notice Reference to the ConsentManager contract for consent verification
     ConsentManager public consentManager;
 
@@ -116,44 +119,33 @@ contract DataBroker {
     function getCreditTier(
         address ownerDID
     ) external returns (IdentityRegistry.CreditTier) {
-        try identityRegistry.getCreditTier(ownerDID) returns (
-            IdentityRegistry.CreditTier tier
-        ) {
-            // Check consent
-            bool hasConsent = consentManager.isConsentGranted(
-                ownerDID,
-                msg.sender
-            );
-            if (!hasConsent) {
-                emit DataAccessDenied(
-                    msg.sender,
-                    ownerDID,
-                    "creditTier",
-                    "No valid consent",
-                    block.timestamp
-                );
-                revert("No valid consent");
-            }
-            // Access granted - emit audit log
-            emit DataAccessGranted(
-                msg.sender,
-                ownerDID,
-                "creditTier",
-                block.timestamp
-            );
-            _maybeReward(ownerDID, msg.sender, "creditTier");
-            return tier;
-        } catch Error(string memory reason) {
-            // User not registered or other error
+        (address storedUser, IdentityRegistry.CreditTier tier, , ) = identityRegistry
+            .identities(ownerDID);
+        if (storedUser == address(0)) {
             emit DataAccessDenied(
                 msg.sender,
                 ownerDID,
                 "creditTier",
-                reason,
+                "Not registered",
                 block.timestamp
             );
-            revert(reason);
+            revert UserNotRegistered();
         }
+
+        if (!_hasConsent(ownerDID)) {
+            emit DataAccessDenied(
+                msg.sender,
+                ownerDID,
+                "creditTier",
+                "No valid consent",
+                block.timestamp
+            );
+            revert ConsentMissing();
+        }
+
+        emit DataAccessGranted(msg.sender, ownerDID, "creditTier", block.timestamp);
+        _maybeReward(ownerDID, msg.sender, "creditTier");
+        return tier;
     }
 
     /**
@@ -164,45 +156,31 @@ contract DataBroker {
     function getIncomeBand(
         address ownerDID
     ) external returns (IdentityRegistry.IncomeBand) {
-        // Check if user is registered first
-        try identityRegistry.getIncomeBand(ownerDID) returns (
-            IdentityRegistry.IncomeBand band
-        ) {
-            // Check consent
-            bool hasConsent = consentManager.isConsentGranted(
-                ownerDID,
-                msg.sender
-            );
-            if (!hasConsent) {
-                emit DataAccessDenied(
-                    msg.sender,
-                    ownerDID,
-                    "incomeBand",
-                    "No valid consent",
-                    block.timestamp
-                );
-                revert("No valid consent");
-            }
-            // Access granted - emit audit log
-            emit DataAccessGranted(
-                msg.sender,
-                ownerDID,
-                "incomeBand",
-                block.timestamp
-            );
-            _maybeReward(ownerDID, msg.sender, "incomeBand");
-            return band;
-        } catch Error(string memory reason) {
-            // User not registered or other error
+        (address storedUser, , IdentityRegistry.IncomeBand band, ) = identityRegistry
+            .identities(ownerDID);
+        if (storedUser == address(0)) {
             emit DataAccessDenied(
                 msg.sender,
                 ownerDID,
                 "incomeBand",
-                reason,
+                "Not registered",
                 block.timestamp
             );
-            revert(reason);
+            revert UserNotRegistered();
         }
+        if (!_hasConsent(ownerDID)) {
+            emit DataAccessDenied(
+                msg.sender,
+                ownerDID,
+                "incomeBand",
+                "No valid consent",
+                block.timestamp
+            );
+            revert ConsentMissing();
+        }
+        emit DataAccessGranted(msg.sender, ownerDID, "incomeBand", block.timestamp);
+        _maybeReward(ownerDID, msg.sender, "incomeBand");
+        return band;
     }
 
     /**
@@ -227,5 +205,9 @@ contract DataBroker {
             dataType,
             block.timestamp
         );
+    }
+
+    function _hasConsent(address ownerDID) internal view returns (bool) {
+        return consentManager.isConsentGranted(ownerDID, msg.sender);
     }
 }

--- a/contracts/DataBroker.sol
+++ b/contracts/DataBroker.sol
@@ -119,9 +119,11 @@ contract DataBroker {
     function getCreditTier(
         address ownerDID
     ) external returns (IdentityRegistry.CreditTier) {
-        (address storedUser, IdentityRegistry.CreditTier tier, , ) = identityRegistry
-            .identities(ownerDID);
-        if (storedUser == address(0)) {
+        (
+            IdentityRegistry.Identity memory identity,
+            bool isRegistered
+        ) = identityRegistry.getIdentity(ownerDID);
+        if (!isRegistered) {
             emit DataAccessDenied(
                 msg.sender,
                 ownerDID,
@@ -145,7 +147,7 @@ contract DataBroker {
 
         emit DataAccessGranted(msg.sender, ownerDID, "creditTier", block.timestamp);
         _maybeReward(ownerDID, msg.sender, "creditTier");
-        return tier;
+        return identity.creditTier;
     }
 
     /**
@@ -156,9 +158,11 @@ contract DataBroker {
     function getIncomeBand(
         address ownerDID
     ) external returns (IdentityRegistry.IncomeBand) {
-        (address storedUser, , IdentityRegistry.IncomeBand band, ) = identityRegistry
-            .identities(ownerDID);
-        if (storedUser == address(0)) {
+        (
+            IdentityRegistry.Identity memory identity,
+            bool isRegistered
+        ) = identityRegistry.getIdentity(ownerDID);
+        if (!isRegistered) {
             emit DataAccessDenied(
                 msg.sender,
                 ownerDID,
@@ -180,7 +184,7 @@ contract DataBroker {
         }
         emit DataAccessGranted(msg.sender, ownerDID, "incomeBand", block.timestamp);
         _maybeReward(ownerDID, msg.sender, "incomeBand");
-        return band;
+        return identity.incomeBand;
     }
 
     /**

--- a/contracts/IdentityRegistry.sol
+++ b/contracts/IdentityRegistry.sol
@@ -167,11 +167,14 @@ contract IdentityRegistry {
     function updateDataPointer(
         bytes32 dataPointer
     ) external onlyRegistered {
-        identities[msg.sender].dataPointer = dataPointer;
+        Identity storage identity = identities[msg.sender];
+        if (identity.dataPointer != dataPointer) {
+            identity.dataPointer = dataPointer;
+        }
         emit ProfileUpdated(
             msg.sender,
-            identities[msg.sender].creditTier,
-            identities[msg.sender].incomeBand,
+            identity.creditTier,
+            identity.incomeBand,
             dataPointer,
             msg.sender,
             block.timestamp
@@ -189,14 +192,19 @@ contract IdentityRegistry {
         IncomeBand incomeBand,
         address userDID
     ) external onlyValidator {
-        if (identities[userDID].userDID == address(0)) revert NotRegistered();
-        identities[userDID].creditTier = creditTier;
-        identities[userDID].incomeBand = incomeBand;
+        Identity storage identity = identities[userDID];
+        if (identity.userDID == address(0)) revert NotRegistered();
+        if (identity.creditTier != creditTier) {
+            identity.creditTier = creditTier;
+        }
+        if (identity.incomeBand != incomeBand) {
+            identity.incomeBand = incomeBand;
+        }
         emit ProfileUpdated(
             userDID,
             creditTier,
             incomeBand,
-            identities[userDID].dataPointer,
+            identity.dataPointer,
             msg.sender,
             block.timestamp
         );
@@ -208,8 +216,9 @@ contract IdentityRegistry {
      * @return Credit tier classification
      */
     function getCreditTier(address userDID) external view returns (CreditTier) {
-        require(identities[userDID].userDID != address(0), "Not registered");
-        return identities[userDID].creditTier;
+        Identity storage identity = identities[userDID];
+        if (identity.userDID == address(0)) revert NotRegistered();
+        return identity.creditTier;
     }
 
     /**
@@ -218,7 +227,8 @@ contract IdentityRegistry {
      * @return Income band classification
      */
     function getIncomeBand(address userDID) external view returns (IncomeBand) {
-        require(identities[userDID].userDID != address(0), "Not registered");
-        return identities[userDID].incomeBand;
+        Identity storage identity = identities[userDID];
+        if (identity.userDID == address(0)) revert NotRegistered();
+        return identity.incomeBand;
     }
 }

--- a/contracts/IdentityRegistry.sol
+++ b/contracts/IdentityRegistry.sol
@@ -170,15 +170,15 @@ contract IdentityRegistry {
         Identity storage identity = identities[msg.sender];
         if (identity.dataPointer != dataPointer) {
             identity.dataPointer = dataPointer;
+            emit ProfileUpdated(
+                msg.sender,
+                identity.creditTier,
+                identity.incomeBand,
+                dataPointer,
+                msg.sender,
+                block.timestamp
+            );
         }
-        emit ProfileUpdated(
-            msg.sender,
-            identity.creditTier,
-            identity.incomeBand,
-            dataPointer,
-            msg.sender,
-            block.timestamp
-        );
     }
 
     /**
@@ -194,20 +194,25 @@ contract IdentityRegistry {
     ) external onlyValidator {
         Identity storage identity = identities[userDID];
         if (identity.userDID == address(0)) revert NotRegistered();
+        bool changed;
         if (identity.creditTier != creditTier) {
             identity.creditTier = creditTier;
+            changed = true;
         }
         if (identity.incomeBand != incomeBand) {
             identity.incomeBand = incomeBand;
+            changed = true;
         }
-        emit ProfileUpdated(
-            userDID,
-            creditTier,
-            incomeBand,
-            identity.dataPointer,
-            msg.sender,
-            block.timestamp
-        );
+        if (changed) {
+            emit ProfileUpdated(
+                userDID,
+                creditTier,
+                incomeBand,
+                identity.dataPointer,
+                msg.sender,
+                block.timestamp
+            );
+        }
     }
 
     /**
@@ -230,5 +235,18 @@ contract IdentityRegistry {
         Identity storage identity = identities[userDID];
         if (identity.userDID == address(0)) revert NotRegistered();
         return identity.incomeBand;
+    }
+
+    /**
+     * @notice Fetch the full identity and registration status in one call
+     * @param userDID Address of the user to query
+     * @return identity Identity data (zeroed if not registered)
+     * @return isRegistered True if the user is registered
+     */
+    function getIdentity(
+        address userDID
+    ) external view returns (Identity memory identity, bool isRegistered) {
+        identity = identities[userDID];
+        isRegistered = identity.userDID != address(0);
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3075,7 +3075,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3528,6 +3527,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4461,7 +4461,6 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/test/DataBroker.t.sol
+++ b/test/DataBroker.t.sol
@@ -103,7 +103,7 @@ contract DataBrokerTest is Test {
     }
 
     function test_GetCreditTier_RevertIfNoConsent() public {
-        vm.expectRevert("No valid consent");
+        vm.expectRevert(DataBroker.ConsentMissing.selector);
         vm.prank(requester);
         dataBroker.getCreditTier(user);
     }
@@ -113,7 +113,7 @@ contract DataBrokerTest is Test {
         emit DataBroker.DataAccessDenied(requester, user, "creditTier", "No valid consent", block.timestamp);
         
         vm.prank(requester);
-        vm.expectRevert("No valid consent");
+        vm.expectRevert(DataBroker.ConsentMissing.selector);
         dataBroker.getCreditTier(user);
     }
 
@@ -124,7 +124,7 @@ contract DataBrokerTest is Test {
         emit DataBroker.DataAccessDenied(requester, unregisteredUser, "creditTier", "Not registered", block.timestamp);
         
         vm.prank(requester);
-        vm.expectRevert("Not registered");
+        vm.expectRevert(DataBroker.UserNotRegistered.selector);
         dataBroker.getCreditTier(unregisteredUser);
     }
 
@@ -145,7 +145,7 @@ contract DataBrokerTest is Test {
         consentManager.changeStatus(user, consentID, ConsentManager.ConsentStatus.Revoked);
         
         // Should revert
-        vm.expectRevert("No valid consent");
+        vm.expectRevert(DataBroker.ConsentMissing.selector);
         vm.prank(requester);
         dataBroker.getCreditTier(user);
     }
@@ -192,7 +192,7 @@ contract DataBrokerTest is Test {
     }
 
     function test_GetIncomeBand_RevertIfNoConsent() public {
-        vm.expectRevert("No valid consent");
+        vm.expectRevert(DataBroker.ConsentMissing.selector);
         vm.prank(requester);
         dataBroker.getIncomeBand(user);
     }
@@ -202,14 +202,14 @@ contract DataBrokerTest is Test {
         emit DataBroker.DataAccessDenied(requester, user, "incomeBand", "No valid consent", block.timestamp);
         
         vm.prank(requester);
-        vm.expectRevert("No valid consent");
+        vm.expectRevert(DataBroker.ConsentMissing.selector);
         dataBroker.getIncomeBand(user);
     }
 
     function test_GetIncomeBand_RevertIfNotRegistered() public {
         address unregisteredUser = address(0x999);
         
-        vm.expectRevert("Not registered");
+        vm.expectRevert(DataBroker.UserNotRegistered.selector);
         vm.prank(requester);
         dataBroker.getIncomeBand(unregisteredUser);
     }
@@ -234,7 +234,7 @@ contract DataBrokerTest is Test {
         assertEq(uint8(tier), uint8(IdentityRegistry.CreditTier.MidGold));
         
         // otherRequester cannot access
-        vm.expectRevert("No valid consent");
+        vm.expectRevert(DataBroker.ConsentMissing.selector);
         vm.prank(otherRequester);
         dataBroker.getCreditTier(user);
     }

--- a/test/GasBenchmarks.t.sol
+++ b/test/GasBenchmarks.t.sol
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {ConsentManager} from "../contracts/ConsentManager.sol";
+import {IdentityRegistry} from "../contracts/IdentityRegistry.sol";
+import {DataBroker} from "../contracts/DataBroker.sol";
+import {DataSharingToken} from "../contracts/DataSharingToken.sol";
+
+contract GasBenchmarks is Test {
+    struct Stat {
+        string label;
+        uint256 gasUsed;
+    }
+
+    address internal constant VALIDATOR =
+        0x0000000000000000000000042000000000000000;
+    uint256 internal constant RUNS = 5;
+    uint256 internal addrSalt;
+
+    function test_GasReport() public {
+        Stat[] memory deployments = new Stat[](4);
+        deployments[0] = Stat({
+            label: "IdentityRegistry deploy",
+            gasUsed: _measureIdentityRegistryDeploy()
+        });
+        deployments[1] = Stat({
+            label: "ConsentManager deploy",
+            gasUsed: _measureConsentManagerDeploy()
+        });
+        deployments[2] = Stat({
+            label: "DataSharingToken deploy",
+            gasUsed: _measureDataSharingTokenDeploy()
+        });
+        deployments[3] = Stat({
+            label: "DataBroker deploy",
+            gasUsed: _measureDataBrokerDeploy()
+        });
+
+        Stat[] memory calls = new Stat[](7);
+        calls[0] = Stat({
+            label: "IdentityRegistry.register",
+            gasUsed: _average(RUNS, _measureRegister)
+        });
+        calls[1] = Stat({
+            label: "IdentityRegistry.updateProfile",
+            gasUsed: _average(RUNS, _measureUpdateProfile)
+        });
+        calls[2] = Stat({
+            label: "IdentityRegistry.updateDataPointer",
+            gasUsed: _average(RUNS, _measureUpdateDataPointer)
+        });
+        calls[3] = Stat({
+            label: "ConsentManager.createConsent",
+            gasUsed: _average(RUNS, _measureCreateConsent)
+        });
+        calls[4] = Stat({
+            label: "ConsentManager.changeStatus",
+            gasUsed: _average(RUNS, _measureChangeConsentStatus)
+        });
+        calls[5] = Stat({
+            label: "DataBroker.getCreditTier (steady)",
+            gasUsed: _average(RUNS, _measureGetCreditTierSteadyState)
+        });
+        calls[6] = Stat({
+            label: "DataBroker.getIncomeBand (steady)",
+            gasUsed: _average(RUNS, _measureGetIncomeBandSteadyState)
+        });
+
+        _logDeployments(deployments);
+        _logCalls(calls);
+
+        // Basic sanity check to ensure we actually collected numbers
+        assertGt(calls[5].gasUsed, 0);
+        assertGt(calls[6].gasUsed, 0);
+    }
+
+    function _measureIdentityRegistryDeploy() internal returns (uint256) {
+        uint256 gasBefore = gasleft();
+        new IdentityRegistry();
+        return gasBefore - gasleft();
+    }
+
+    function _measureConsentManagerDeploy() internal returns (uint256) {
+        uint256 gasBefore = gasleft();
+        new ConsentManager();
+        return gasBefore - gasleft();
+    }
+
+    function _measureDataSharingTokenDeploy() internal returns (uint256) {
+        uint256 gasBefore = gasleft();
+        new DataSharingToken("Credit Data Sharing Token", "CDST");
+        return gasBefore - gasleft();
+    }
+
+    function _measureDataBrokerDeploy() internal returns (uint256) {
+        vm.pauseGasMetering();
+        ConsentManager consentManager = new ConsentManager();
+        IdentityRegistry identityRegistry = new IdentityRegistry();
+        DataSharingToken token = new DataSharingToken(
+            "Credit Data Sharing Token",
+            "CDST"
+        );
+        vm.resumeGasMetering();
+
+        uint256 gasBefore = gasleft();
+        new DataBroker(
+            address(consentManager),
+            address(identityRegistry),
+            address(token),
+            10 ether
+        );
+        return gasBefore - gasleft();
+    }
+
+    function _measureRegister() internal returns (uint256) {
+        vm.pauseGasMetering();
+        IdentityRegistry identityRegistry = new IdentityRegistry();
+        address user = _nextAddress("register");
+        vm.resumeGasMetering();
+
+        vm.prank(user);
+        uint256 gasBefore = gasleft();
+        identityRegistry.register();
+        uint256 gasUsed = gasBefore - gasleft();
+        vm.pauseGasMetering();
+        return gasUsed;
+    }
+
+    function _measureUpdateProfile() internal returns (uint256) {
+        vm.pauseGasMetering();
+        IdentityRegistry identityRegistry = new IdentityRegistry();
+        address user = _nextAddress("profile");
+        vm.prank(user);
+        identityRegistry.register();
+        vm.resumeGasMetering();
+
+        vm.prank(VALIDATOR);
+        uint256 gasBefore = gasleft();
+        identityRegistry.updateProfile(
+            IdentityRegistry.CreditTier.MidGold,
+            IdentityRegistry.IncomeBand.upto150k,
+            user
+        );
+        uint256 gasUsed = gasBefore - gasleft();
+        vm.pauseGasMetering();
+        return gasUsed;
+    }
+
+    function _measureUpdateDataPointer() internal returns (uint256) {
+        vm.pauseGasMetering();
+        IdentityRegistry identityRegistry = new IdentityRegistry();
+        address user = _nextAddress("pointer");
+        vm.prank(user);
+        identityRegistry.register();
+        bytes32 pointer = keccak256(abi.encodePacked(user, block.timestamp));
+        vm.resumeGasMetering();
+
+        vm.prank(user);
+        uint256 gasBefore = gasleft();
+        identityRegistry.updateDataPointer(pointer);
+        uint256 gasUsed = gasBefore - gasleft();
+        vm.pauseGasMetering();
+        return gasUsed;
+    }
+
+    function _measureCreateConsent() internal returns (uint256) {
+        vm.pauseGasMetering();
+        ConsentManager consentManager = new ConsentManager();
+        address user = _nextAddress("consent-user");
+        address requester = _nextAddress("consent-requester");
+        uint96 startDate = uint96(block.timestamp);
+        uint96 endDate = startDate + uint96(30 days);
+        vm.resumeGasMetering();
+
+        vm.prank(user);
+        uint256 gasBefore = gasleft();
+        consentManager.createConsent(requester, user, startDate, endDate);
+        uint256 gasUsed = gasBefore - gasleft();
+        vm.pauseGasMetering();
+        return gasUsed;
+    }
+
+    function _measureChangeConsentStatus() internal returns (uint256) {
+        vm.pauseGasMetering();
+        ConsentManager consentManager = new ConsentManager();
+        address user = _nextAddress("status-user");
+        address requester = _nextAddress("status-requester");
+        uint96 startDate = uint96(block.timestamp);
+        uint96 endDate = startDate + uint96(30 days);
+        vm.prank(user);
+        consentManager.createConsent(requester, user, startDate, endDate);
+        bytes32 consentID = keccak256(abi.encodePacked(requester, user));
+        vm.resumeGasMetering();
+
+        vm.prank(user);
+        uint256 gasBefore = gasleft();
+        consentManager.changeStatus(
+            user,
+            consentID,
+            ConsentManager.ConsentStatus.Granted
+        );
+        uint256 gasUsed = gasBefore - gasleft();
+        vm.pauseGasMetering();
+        return gasUsed;
+    }
+
+    function _measureGetCreditTierSteadyState() internal returns (uint256) {
+        vm.pauseGasMetering();
+        (DataBroker dataBroker, address user, address requester) = _prepareBrokerStack();
+        vm.prank(requester);
+        dataBroker.getCreditTier(user); // warm-up to avoid counting reward minting cost
+        vm.resumeGasMetering();
+
+        vm.prank(requester);
+        uint256 gasBefore = gasleft();
+        dataBroker.getCreditTier(user);
+        uint256 gasUsed = gasBefore - gasleft();
+        vm.pauseGasMetering();
+        return gasUsed;
+    }
+
+    function _measureGetIncomeBandSteadyState() internal returns (uint256) {
+        vm.pauseGasMetering();
+        (DataBroker dataBroker, address user, address requester) = _prepareBrokerStack();
+        vm.prank(requester);
+        dataBroker.getCreditTier(user); // warm-up reward and consent path
+        vm.resumeGasMetering();
+
+        vm.prank(requester);
+        uint256 gasBefore = gasleft();
+        dataBroker.getIncomeBand(user);
+        uint256 gasUsed = gasBefore - gasleft();
+        vm.pauseGasMetering();
+        return gasUsed;
+    }
+
+    function _prepareBrokerStack()
+        internal
+        returns (DataBroker dataBroker, address user, address requester)
+    {
+        ConsentManager consentManager = new ConsentManager();
+        IdentityRegistry identityRegistry = new IdentityRegistry();
+        DataSharingToken rewardToken = new DataSharingToken(
+            "Credit Data Sharing Token",
+            "CDST"
+        );
+        dataBroker = new DataBroker(
+            address(consentManager),
+            address(identityRegistry),
+            address(rewardToken),
+            10 ether
+        );
+        rewardToken.addMinter(address(dataBroker));
+
+        user = _nextAddress("broker-user");
+        requester = _nextAddress("broker-requester");
+
+        vm.prank(user);
+        identityRegistry.register();
+
+        vm.prank(VALIDATOR);
+        identityRegistry.updateProfile(
+            IdentityRegistry.CreditTier.MidGold,
+            IdentityRegistry.IncomeBand.upto150k,
+            user
+        );
+
+        uint96 startDate = uint96(block.timestamp);
+        uint96 endDate = startDate + uint96(30 days);
+
+        vm.prank(user);
+        consentManager.createConsent(requester, user, startDate, endDate);
+
+        bytes32 consentID = keccak256(abi.encodePacked(requester, user));
+        vm.prank(user);
+        consentManager.changeStatus(
+            user,
+            consentID,
+            ConsentManager.ConsentStatus.Granted
+        );
+    }
+
+    function _logDeployments(Stat[] memory deployments) internal pure {
+        console2.log("\nDeployment gas summary:");
+        for (uint256 i = 0; i < deployments.length; i++) {
+            console2.log(deployments[i].label, deployments[i].gasUsed);
+        }
+    }
+
+    function _logCalls(Stat[] memory calls) internal pure {
+        console2.log("\nFunction call gas averages:");
+        console2.log("Runs", RUNS);
+        for (uint256 i = 0; i < calls.length; i++) {
+            console2.log(calls[i].label, calls[i].gasUsed);
+        }
+    }
+
+    function _average(
+        uint256 runs,
+        function() internal returns (uint256) measureFn
+    ) internal returns (uint256) {
+        uint256 total;
+        for (uint256 i = 0; i < runs; i++) {
+            total += measureFn();
+        }
+        return total / runs;
+    }
+
+    function _nextAddress(string memory tag) internal returns (address) {
+        addrSalt++;
+        return
+            address(
+                uint160(uint256(keccak256(abi.encodePacked(tag, addrSalt))))
+            );
+    }
+}

--- a/test/IdentityRegistry.t.sol
+++ b/test/IdentityRegistry.t.sol
@@ -288,6 +288,45 @@ contract IdentityRegistryTest is Test {
         identityRegistry.getIncomeBand(user);
     }
 
+    // ============ New Getter Tests ============
+
+    function test_GetIdentity_ReturnsDataAndFlag() public {
+        vm.prank(user);
+        identityRegistry.register();
+
+        bytes32 dataPointer = keccak256("test-data");
+        vm.prank(user);
+        identityRegistry.updateDataPointer(dataPointer);
+
+        vm.prank(validator);
+        identityRegistry.updateProfile(
+            IdentityRegistry.CreditTier.MidGold,
+            IdentityRegistry.IncomeBand.upto150k,
+            user
+        );
+
+        (
+            IdentityRegistry.Identity memory identity,
+            bool isRegistered
+        ) = identityRegistry.getIdentity(user);
+
+        assertTrue(isRegistered);
+        assertEq(identity.userDID, user);
+        assertEq(uint8(identity.creditTier), uint8(IdentityRegistry.CreditTier.MidGold));
+        assertEq(uint8(identity.incomeBand), uint8(IdentityRegistry.IncomeBand.upto150k));
+        assertEq(identity.dataPointer, dataPointer);
+    }
+
+    function test_GetIdentity_NotRegisteredReturnsFalse() public view {
+        (
+            IdentityRegistry.Identity memory identity,
+            bool isRegistered
+        ) = identityRegistry.getIdentity(user);
+
+        assertFalse(isRegistered);
+        assertEq(identity.userDID, address(0));
+    }
+
     // ============ Verify Address Ownership Tests ============
     
     function test_VerifyAddressOwnership_ValidSignature() public view {

--- a/test/IdentityRegistry.t.sol
+++ b/test/IdentityRegistry.t.sol
@@ -264,7 +264,7 @@ contract IdentityRegistryTest is Test {
     }
 
     function test_GetCreditTier_RevertIfNotRegistered() public {
-        vm.expectRevert("Not registered");
+        vm.expectRevert(IdentityRegistry.NotRegistered.selector);
         identityRegistry.getCreditTier(user);
     }
 
@@ -284,7 +284,7 @@ contract IdentityRegistryTest is Test {
     }
 
     function test_GetIncomeBand_RevertIfNotRegistered() public {
-        vm.expectRevert("Not registered");
+        vm.expectRevert(IdentityRegistry.NotRegistered.selector);
         identityRegistry.getIncomeBand(user);
     }
 


### PR DESCRIPTION
**Code changes:**
- Reduced redundant storage writes in contracts/IdentityRegistry.sol by guarding profile/dataPointer updates and swapped string reverts for custom errors in getters to shave gas on hot paths.
- Simplified contracts/DataBroker.sol lookups (no try/catch), introduced custom errors, and kept denial/grant events while checking registration/consent up front to cut call overhead.
- Added test/GasBenchmarks.t.sol to benchmark deployments and steady-state call costs with paused gas metering for setup; updated existing tests to expect custom errors.

**Gas Summary (from test_GasReport steady-state averages, 5 runs):**

1. Deployment: IdentityRegistry 1,048,785 | ConsentManager 803,324 | DataSharingToken 1,180,670 | DataBroker 1,061,613
2. Calls: register 27,256 | updateProfile 6,492 | updateDataPointer 25,038 | createConsent 73,338 | changeStatus 5,983 | getCreditTier 11,862 | getIncomeBand 11,907